### PR TITLE
Fix callback function bug in getManagedInstanceByOrgId

### DIFF
--- a/src/commands/appops/deploy.ts
+++ b/src/commands/appops/deploy.ts
@@ -384,19 +384,18 @@ export default class Org extends SfdxCommand {
 
     let managedInstance = undefined;
     
-    await hubConn.request(`${hubConn.instanceUrl}${path}`, function(err, res) {
-        if (err) { 
-            throw new SfError(err); 
-        }
-        console.log("Get managed instance response: ", JSON.stringify(res));
-        let managedInstances : ManagedInstances = JSON.parse( JSON.stringify(res) );
+    try {
+        const instancesRes = await hubConn.request(`${hubConn.instanceUrl}${path}`);
+        let managedInstances : ManagedInstances = JSON.parse( JSON.stringify(instancesRes) );
         managedInstances.instances.forEach( (instance) => {
             if( instance.platformInstanceId === orgId ) {
                 console.log("Found matching instance: ", instance);
                 managedInstance = instance;
             }
         });
-    });
+    } catch (err) {
+        throw new SfError(err); 
+    }
 
     return managedInstance;
   }  


### PR DESCRIPTION
## Description of the change

The callback function getting passed to `hubConn.request()` [on line 387](https://github.com/prodly/appops-dx-cli/blob/master/src/commands/appops/deploy.ts#L387) is not getting executed which results in `ERROR running appops:deploy:  Cannot read properties of undefined (reading 'id')`

I was able to avoid this error by storing the `hubConn.request()` in a variable and wrapping that in a try/catch block.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Security impact

## Related issues

N/A. I have a support case open about this issue:
- Case #: 00004982
- Case Link: https://success.prodly.co/s/case/5002L00001oXQhqQAG/prodly-appopsdxcl-errors

## Checklists

### Development

- [ ] Static analysis passes locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] Security design review for any security impacting changes

### Code review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
